### PR TITLE
Improved Bazin Fit

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,27 +50,27 @@ You will need to install the `Python` package ``virtualenv``. In MacOS or Linux,
 
 Navigate to a ``env_directory`` where you will store the new virtual environment and create it  
 
-    >> python3 -m venv RESSPECT  
+    >> python3 -m venv RESSPECT
 
 > Make sure you deactivate any ``conda`` environment you might have running before moving forward.   
 
 Once the environment is set up you can activate it,
 
-    >> source <env_directory>/bin/activate  
+    >> source <env_directory>/bin/activate
 
 You should see a ``(RESSPECT)`` flag in the extreme left of terminal command line.   
 
 Next, clone this repository in another chosen location:  
 
-    (RESSPECT) >> git clone https://github.com/COINtoolbox/RESSPECT.git  
+    (RESSPECT) >> git clone https://github.com/COINtoolbox/RESSPECT.git
 
 Navigate to the repository folder and do  
 
-    (RESSPECT) >> pip install -r requirements.txt  
+    (RESSPECT) >> pip install -r requirements.txt
 
 
 You can now install this package with:  
 
-    (RESSPECT) >>> python setup.py install  
+    (RESSPECT) >>> python setup.py install
 
 > You may choose to create your virtual environment within the folder of the repository. If you choose to do this, you must remember to exclude the virtual environment directory from version control using e.g., ``.gitignore``.   

--- a/docs/pre_processing.rst
+++ b/docs/pre_processing.rst
@@ -167,7 +167,7 @@ The designation for each parameter are stored in:
    :linenos:
 
    >>> lc.bazin_features_names
-   ['a', 'b', 't0', 'tfall', 'trsise']
+   ['a', 'b', 't0', 'tfall', 'r']
 
 It is possible to perform the fit in all filters at once and visualize the result using:
 

--- a/docs/pre_processing.rst
+++ b/docs/pre_processing.rst
@@ -167,7 +167,7 @@ The designation for each parameter are stored in:
    :linenos:
 
    >>> lc.bazin_features_names
-   ['a', 'b', 't0', 'tfall', 'r']
+   ['a', 'b', 't0', 'tfall', 'trsise']
 
 It is possible to perform the fit in all filters at once and visualize the result using:
 

--- a/docs/pre_processing.rst
+++ b/docs/pre_processing.rst
@@ -167,7 +167,7 @@ The designation for each parameter are stored in:
    :linenos:
 
    >>> lc.bazin_features_names
-   ['a', 'b', 't0', 'tfall', 'trsise']
+   ['a', 'b', 't0', 'tfall', 'trise']
 
 It is possible to perform the fit in all filters at once and visualize the result using:
 

--- a/resspect/bazin.py
+++ b/resspect/bazin.py
@@ -103,7 +103,7 @@ def errfunc(params, time, flux, fluxerr):
 
     """
 
-    return abs(flux - bazin(time, *params)) / fluxerr
+    return abs(flux - bazinr(time, *params)) / fluxerr
 
 
 def fit_scipy(time, flux, fluxerr):

--- a/resspect/bazin.py
+++ b/resspect/bazin.py
@@ -39,9 +39,10 @@ def bazin(time, a, b, t0, tfall, r):
         Time of maximum
     tfall: float
         Characteristic decline time
+    # trise: float
+    #     Characteristic raise time
     r: float
-        Ratio of the characteristic decline time (tfall) and the characteristic raise time (trise). This ratio is enforced to be >1.
-
+        WRITE ABOUT r
 
     Returns
     -------
@@ -51,6 +52,7 @@ def bazin(time, a, b, t0, tfall, r):
     """
     with np.errstate(over='ignore', invalid='ignore'):
         e = np.exp(-(time - t0) / tfall)
+        # r = tfall / trise
         X = e / (1  + e**r)
         return a * X + b
 
@@ -61,7 +63,7 @@ def errfunc(params, time, flux, fluxerr):
     Parameters
     ----------
     params : list of float
-        light curve parameters: (a, b, t0, tfall, r)
+        light curve parameters: (a, b, t0, tfall, trise)
     time : array_like
         exploratory variable (time of observation)
     flux : array_like

--- a/resspect/bazin.py
+++ b/resspect/bazin.py
@@ -129,6 +129,13 @@ def fit_scipy(time, flux, fluxerr):
     imax = flux.argmax()
     flux_max = flux[imax]
     
+    # Parameter bounds
+    a_bounds = [1.e-3, np.inf]
+    b_bounds = [-np.inf, np.inf]
+    t0_bounds = [-0.5*time.max(), 1.5*time.max()]
+    tfall_bounds = [1.e-3, np.inf]
+    r_bounds = [1, np.inf]
+
     # Parameter guess
     a_guess = 2*flux_max
     b_guess = 0
@@ -144,15 +151,17 @@ def fit_scipy(time, flux, fluxerr):
 
     r_guess = 2
 
+    # Clip guesses to stay in bound
+    a_guess = np.clip(a=a_guess,a_min=a_bounds[0],a_max=a_bounds[1])
+    b_guess = np.clip(a=b_guess,a_min=b_bounds[0],a_max=b_bounds[1])
+    t0_guess = np.clip(a=t0_guess,a_min=t0_bounds[0],a_max=t0_bounds[1])
+    tfall_guess = np.clip(a=tfall_guess,a_min=tfall_bounds[0],a_max=tfall_bounds[1])
+    r_guess = np.clip(a=r_guess,a_min=r_bounds[0],a_max=r_bounds[1])
+
+
     guess = [a_guess,b_guess,t0_guess,tfall_guess,r_guess]
 
-    # Parameter bounds
-    a_bounds = [1.e-3, np.inf]
-    b_bounds = [-np.inf, np.inf]
-    t0_bounds = [-0.5*time.max(), 1.5*time.max()]
-    tfall_bounds = [1.e-3, np.inf]
-    r_bounds = [1, np.inf]
-    
+
     bounds = [[a_bounds[0], b_bounds[0], t0_bounds[0], tfall_bounds[0], r_bounds[0]],
               [a_bounds[1], b_bounds[1], t0_bounds[1], tfall_bounds[1], r_bounds[1]]]
     

--- a/resspect/bazin.py
+++ b/resspect/bazin.py
@@ -39,10 +39,9 @@ def bazin(time, a, b, t0, tfall, r):
         Time of maximum
     tfall: float
         Characteristic decline time
-    # trise: float
-    #     Characteristic raise time
     r: float
-        WRITE ABOUT r
+        Ratio of the characteristic decline time (tfall) and the characteristic raise time (trise). This ratio is enforced to be >1.
+
 
     Returns
     -------
@@ -52,7 +51,6 @@ def bazin(time, a, b, t0, tfall, r):
     """
     with np.errstate(over='ignore', invalid='ignore'):
         e = np.exp(-(time - t0) / tfall)
-        # r = tfall / trise
         X = e / (1  + e**r)
         return a * X + b
 
@@ -63,7 +61,7 @@ def errfunc(params, time, flux, fluxerr):
     Parameters
     ----------
     params : list of float
-        light curve parameters: (a, b, t0, tfall, trise)
+        light curve parameters: (a, b, t0, tfall, r)
     time : array_like
         exploratory variable (time of observation)
     flux : array_like

--- a/resspect/bazin.py
+++ b/resspect/bazin.py
@@ -134,9 +134,9 @@ def fit_scipy(time, flux, fluxerr):
     b_guess = 0
     t0_guess = time[imax]
     
-    tfall_guess = t[imax-2:imax+2].std()/2
+    tfall_guess = time[imax-2:imax+2].std()/2
     if np.isnan(tfall_guess):
-        tfall_guess = t[imax-1:imax+1].std()/2
+        tfall_guess = time[imax-1:imax+1].std()/2
         if np.isnan(tfall_guess):
             tfall_guess=50
     if tfall_guess<1:

--- a/resspect/bazin.py
+++ b/resspect/bazin.py
@@ -102,11 +102,11 @@ def fit_scipy(time, flux, fluxerr):
     imax = flux.argmax()
     t0 = time[imax]
     try:
-        scale = time[imax-2:imax+2].std()/2
+        scale = t[imax-2:imax+2].std()/2
         assert(not np.isnan(scale))
     except:
         try:
-            scale = time[imax-1:imax+1].std()/2
+            scale = t[imax-1:imax+1].std()/2
             assert(not np.isnan(scale))
         except:
             scale=50

--- a/resspect/bazin.py
+++ b/resspect/bazin.py
@@ -117,7 +117,7 @@ def fit_scipy(time, flux, fluxerr):
     A = 2*flux.max()
     #guess = [A, 0, t0, scale, scale/2]
     guess = [A, 0, t0, scale, 2.]
-    result = sciopt.least_squares(errfunc, guess, args=(time, flux, fluxerr), method='trf', loss='linear',\
+    result = least_squares(errfunc, guess, args=(time, flux, fluxerr), method='trf', loss='linear',\
                                   bounds=([1.e-3, -np.inf, 0, 1.e-3, 1], np.inf))
 
     return result.x

--- a/resspect/bazin.py
+++ b/resspect/bazin.py
@@ -117,7 +117,7 @@ def fit_scipy(time, flux, fluxerr):
     A = 2*flux.max()
     #guess = [A, 0, t0, scale, scale/2]
     guess = [A, 0, t0, scale, 2.]
-    result = least_squares(errfunc, guess, args=(time, flux, fluxerr), method='trf', loss='linear',\
+    result = sciopt.least_squares(errfunc, guess, args=(time, flux, fluxerr), method='trf', loss='linear',\
                                   bounds=([1.e-3, -np.inf, 0, 1.e-3, 1], np.inf))
 
     return result.x

--- a/resspect/bazin.py
+++ b/resspect/bazin.py
@@ -102,11 +102,11 @@ def fit_scipy(time, flux, fluxerr):
     imax = flux.argmax()
     t0 = time[imax]
     try:
-        scale = t[imax-2:imax+2].std()/2
+        scale = time[imax-2:imax+2].std()/2
         assert(not np.isnan(scale))
     except:
         try:
-            scale = t[imax-1:imax+1].std()/2
+            scale = time[imax-1:imax+1].std()/2
             assert(not np.isnan(scale))
         except:
             scale=50

--- a/resspect/fit_lightcurves.py
+++ b/resspect/fit_lightcurves.py
@@ -163,7 +163,7 @@ class LightCurve:
 
     def __init__(self):
         self.bazin_features = []
-        self.bazin_features_names = ['a', 'b', 't0', 'tfall', 'trsise']
+        self.bazin_features_names = ['a', 'b', 't0', 'tfall', 'trise']
         self.dataset_name = ' '
         self.exp_time = {}
         self.filters = []

--- a/resspect/fit_lightcurves.py
+++ b/resspect/fit_lightcurves.py
@@ -163,7 +163,7 @@ class LightCurve:
 
     def __init__(self):
         self.bazin_features = []
-        self.bazin_features_names = ['a', 'b', 't0', 'tfall', 'trsise']
+        self.bazin_features_names = ['a', 'b', 't0', 'tfall', 'r']
         self.dataset_name = ' '
         self.exp_time = {}
         self.filters = []
@@ -451,7 +451,7 @@ class LightCurve:
         -------
         bazin_param: np.ndarray
             Best fit parameters for the Bazin function:
-            [a, b, t0, tfall, trise].
+            [a, b, t0, tfall, r].
         """
 
         # build filter flag

--- a/resspect/fit_lightcurves.py
+++ b/resspect/fit_lightcurves.py
@@ -462,9 +462,10 @@ class LightCurve:
         # get info for this filter
         time = self.photometry['mjd'].values[band_indices]
         flux = self.photometry['flux'].values[band_indices]
+        fluxerr = self.photometry['fluxerr'].values[band_indices]
 
         # fit Bazin function
-        bazin_param = fit_scipy(time - time[0], flux)
+        bazin_param = fit_scipy(time - time[0], flux, fluxerr)
         return bazin_param
 
     def evaluate_bazin(self, time: np.array):

--- a/resspect/fit_lightcurves.py
+++ b/resspect/fit_lightcurves.py
@@ -163,7 +163,7 @@ class LightCurve:
 
     def __init__(self):
         self.bazin_features = []
-        self.bazin_features_names = ['a', 'b', 't0', 'tfall', 'r']
+        self.bazin_features_names = ['a', 'b', 't0', 'tfall', 'trsise']
         self.dataset_name = ' '
         self.exp_time = {}
         self.filters = []
@@ -451,7 +451,7 @@ class LightCurve:
         -------
         bazin_param: np.ndarray
             Best fit parameters for the Bazin function:
-            [a, b, t0, tfall, r].
+            [a, b, t0, tfall, trise].
         """
 
         # build filter flag

--- a/resspect/readme.rst
+++ b/resspect/readme.rst
@@ -8,7 +8,7 @@ List of modules:
 
 :batch_functions.py: functions for batch strategies
 :bazin.py: functions to find best-fit parameters to the Bazin function
-:buiold_plasticc_canonical.py: constructs the canonical sample for PLAsTiCC data
+:build_plasticc_canonical.py: constructs the canonical sample for PLAsTiCC data
 :build_snpcc_canonical.py: constructs the canonical sample for SNPCC data
 :classifiers.py: machine learning classifiers
 :cosmo_metrics_utils.py: cosmology metric and auxiliary functions

--- a/resspect/tests/test_bazin.py
+++ b/resspect/tests/test_bazin.py
@@ -23,9 +23,10 @@ def test_bazin():
     b = 1
     t0 = 10
     tfall = 3
-    trise = 4
-    
-    res = bazin(time, a, b, t0, tfall, trise)
+    # trise = 4
+    r = 4
+
+    res = bazin(time, a, b, t0, tfall, r)
     
     assert not np.isnan(res).any()
 
@@ -43,17 +44,19 @@ def test_errfunc():
     b = 1
     t0 = 10
     tfall = 3
-    trise = 4
-    
+    # trise = 4
+    r = 4
+
     # calculate fiducial flux values
-    flux_fid = bazin(time, a, b, t0, tfall, trise)
+    flux_fid = bazin(time, a, b, t0, tfall, r)
     
     # add noise
     flux = [np.random.normal(loc=item, scale=0.01) for item in flux_fid]
     
     # construct parameters vector
-    params = [a, b, t0, tfall, trise]
+    params = [a, b, t0, tfall, r]
 
+    # HAVE TO ADD FLUXERR BELOW AS ERFFUNC WAS CHANGED
     res = errfunc(params, time, flux)
     
     assert not np.isnan(res).any()
@@ -71,8 +74,9 @@ def test_fit_scipy():
     
     time = data['mjd'].values
     flux = data['flux'].values
+    fluxerr = data['fluxerr'].values
     
-    res = fit_scipy(time, flux)
+    res = fit_scipy(time, flux,fluxerr)
     
     assert not np.isnan(res).any()
 

--- a/resspect/tests/test_bazin.py
+++ b/resspect/tests/test_bazin.py
@@ -23,8 +23,8 @@ def test_bazin():
     b = 1
     t0 = 10
     tfall = 3
-    # trise = 4
-    r = 4
+    trise = 4
+    r = tfall/trise
 
     res = bazin(time, a, b, t0, tfall, r)
     
@@ -44,8 +44,8 @@ def test_errfunc():
     b = 1
     t0 = 10
     tfall = 3
-    # trise = 4
-    r = 4
+    trise = 4
+    r = tfall/trise
 
     # calculate fiducial flux values
     flux_fid = bazin(time, a, b, t0, tfall, r)

--- a/resspect/tests/test_bazin.py
+++ b/resspect/tests/test_bazin.py
@@ -24,7 +24,7 @@ def test_bazin():
     t0 = 10
     tfall = 3
     trise = 4
-
+    
     res = bazin(time, a, b, t0, tfall, trise)
     
     assert not np.isnan(res).any()
@@ -55,7 +55,7 @@ def test_errfunc():
     fluxerr = (flux - flux_fid)**2
 
     # construct parameters vector
-    params = [a, b, t0, tfall, r]
+    params = [a, b, t0, tfall, trise]
 
     res = errfunc(params, time, flux, fluxerr)
     

--- a/resspect/tests/test_bazin.py
+++ b/resspect/tests/test_bazin.py
@@ -53,11 +53,13 @@ def test_errfunc():
     # add noise
     flux = [np.random.normal(loc=item, scale=0.01) for item in flux_fid]
     
+    # find error
+    fluxerr = (flux - flux_fid)**2
+
     # construct parameters vector
     params = [a, b, t0, tfall, r]
 
-    # HAVE TO ADD FLUXERR BELOW AS ERFFUNC WAS CHANGED
-    res = errfunc(params, time, flux)
+    res = errfunc(params, time, flux, fluxerr)
     
     assert not np.isnan(res).any()
     assert np.all(res > 0)

--- a/resspect/tests/test_bazin.py
+++ b/resspect/tests/test_bazin.py
@@ -76,7 +76,7 @@ def test_fit_scipy():
     
     time = data['mjd'].values
     flux = data['flux'].values
-    fluxerr = data['fluxerr'].values
+    fluxerr = 1
     
     res = fit_scipy(time, flux,fluxerr)
     

--- a/resspect/tests/test_bazin.py
+++ b/resspect/tests/test_bazin.py
@@ -24,9 +24,8 @@ def test_bazin():
     t0 = 10
     tfall = 3
     trise = 4
-    r = tfall/trise
 
-    res = bazin(time, a, b, t0, tfall, r)
+    res = bazin(time, a, b, t0, tfall, trise)
     
     assert not np.isnan(res).any()
 
@@ -45,10 +44,9 @@ def test_errfunc():
     t0 = 10
     tfall = 3
     trise = 4
-    r = tfall/trise
-
+    
     # calculate fiducial flux values
-    flux_fid = bazin(time, a, b, t0, tfall, r)
+    flux_fid = bazin(time, a, b, t0, tfall, trise)
     
     # add noise
     flux = [np.random.normal(loc=item, scale=0.01) for item in flux_fid]


### PR DESCRIPTION
Johann and I were looking at the Bazin fit and noticed that the Bazin fit was failing for PLAsTiCC objects unexpectedly. For example, the fit was failing for a microlensing example (object_id: 130779836), which is an example of a µ-lens from a single lens. Here's the failed fit:
![before](https://user-images.githubusercontent.com/40721514/120375430-6d0bb200-c338-11eb-935a-ccec2981d1e7.png)

The ratio of `tfall/trise` is supposed to be `>1`, as mentioned in Section 3, [Dai et. al. (2017)](https://arxiv.org/pdf/1701.05689.pdf).

Thus, Johann and I made changes to the 3 functions: `bazin()`, `errfunc()` and `fit_scipy()` coded up the following changes:
1.  Bazin is modified to take the ratio `r=tfall/trise` instead of `trise`. This allows us to enforce the condition `r>1` on the fit.
2.  Flux_err is used as a parameter to errfunc: `abs(flux - bazin(time, *params)) / fluxerr`
3.  Bounds can be added to `fit_scipy()` and a better original guess was chosen to again enforce the condition `r>1`.

Here's the same object as above (object_id: 130779836), now fit with the new code:
![after](https://user-images.githubusercontent.com/40721514/120376841-fa033b00-c339-11eb-9c4b-843fc2e0ce40.png)

There is a clear improvement in the fit for the "u", "r" and "z" bands.