### PR TITLE
Optimize PLAsTiCC time domain feature extraction #102

### DIFF
--- a/resspect/time_domain_plasticc.py
+++ b/resspect/time_domain_plasticc.py
@@ -666,8 +666,9 @@ class PLAsTiCCPhotometry:
         self._number_of_telescopes = len(tel_names)
         self._kwargs = kwargs
         if create_daily_files:
-            self.create_all_daily_files(
-                output_dir=output_dir, get_cost=get_cost)
+            for day_of_survey in range(time_window[0], time_window[1]):
+                self.create_daily_file(output_dir=output_dir,
+                                       day=day_of_survey, get_cost=get_cost)
 
         for day_of_survey in range(time_window[0], time_window[1]):
             # Load previous day features if available

--- a/resspect/time_domain_plasticc.py
+++ b/resspect/time_domain_plasticc.py
@@ -593,6 +593,30 @@ class PLAsTiCCPhotometry:
             with open(features_file_name, 'w') as features_file:
                 features_file.write(' '.join(self._bazin_header) + '\n')
 
+    def _maybe_create_daily_feature_files(
+            self, time_window: list, output_dir: str, get_cost: bool):
+        """
+        Creates daily feature files for the specified time window
+        Parameters
+        ----------
+        time_window
+            Days of the survey to process, in days since the start of the survey.
+            Default is the entire survey = [0, 1095].
+        output_dir
+            Output directory to save feature files
+        get_cost
+           if cost of taking a spectra is computed
+        """
+        user_input = input("Are you sure want to create new daily files?(yes/no): ")
+        if user_input.lower() == "yes":
+            for day_of_survey in range(time_window[0], time_window[1]):
+                self.create_daily_file(output_dir=output_dir,
+                                       day=day_of_survey, get_cost=get_cost)
+        elif user_input.lower() == "no":
+            logging.info("Not creating new daily feature files")
+        else:
+            raise ValueError("Unknown input! Please specify yes or no")
+
     def fit_all_snids_lc(
             self, raw_data_dir: str, snids: np.ndarray, output_dir: str,
             vol: int = None, queryable_criteria: int = 1,
@@ -666,9 +690,8 @@ class PLAsTiCCPhotometry:
         self._number_of_telescopes = len(tel_names)
         self._kwargs = kwargs
         if create_daily_files:
-            for day_of_survey in range(time_window[0], time_window[1]):
-                self.create_daily_file(output_dir=output_dir,
-                                       day=day_of_survey, get_cost=get_cost)
+            self._maybe_create_daily_feature_files(
+                time_window, output_dir, get_cost)
 
         for day_of_survey in range(time_window[0], time_window[1]):
             # Load previous day features if available

--- a/resspect/time_domain_plasticc.py
+++ b/resspect/time_domain_plasticc.py
@@ -137,7 +137,6 @@ class PLAsTiCCPhotometry:
         maybe_create_directory(output_dir)
         self._features_file_name = os.path.join(
             output_dir, 'day_' + str(day) + '.dat')
-        logging.info('Creating features file')
         with open(self._features_file_name, 'w') as features_file:
             self._set_bazin_header(header)
             features_file.write(' '.join(self._bazin_header) + '\n')


### PR DESCRIPTION
Added a new method `fit_all_snids_lc()` in `PLAsTiCCPhotometry` class to process snids as described in #102
The method extracts features for one day at a time and the fitting of snid light curves run in parallel.
Features of a snid  will be copied from previous day if there are no new observing points are available for it.

Example:
```python
from resspect.time_domain_plasticc import PLAsTiCCPhotometry
from resspect.lightcurves_utils import PLASTICC_TARGET_TYPES

output_dir = '/path/to/save/features/'
raw_data_dir = '/path/to/plasticc/files'     # path to PLAsTiCC zenodo files
create_daily_files = True               # create 1 file for each day of survey (do this only once!)
field = 'DDF'                           # DDF or WFD
get_cost = True                         # calculate cost of each observation
queryable_criteria = 2                  # if 2, estimate brightness at time of query
sample = 'test'                         # original plasticc sample
vol = 1                                 # index of plasticc zenodo file for test sample
spec_SNR = 10                           # minimum SNR required for spec follow-up
tel_names = ['4m', '8m']                  # name of telescopes considered for spec follow-up
tel_sizes = [4, 8]                      # size of primay mirrors, in m
number_of_processors = 4               # Number of cpu processes to use.

# start PLAsTiCCPhotometry object
feature_class = PLAsTiCCPhotometry()
feature_class.build()

# at first, create one file per day of the survey, this will creat empty files for [0, 1095]
if create_daily_files:
         feature_class.create_all_daily_files(output_dir=output_dir, get_cost=get_cost)
# read metadata
feature_class.read_metadata(
                     path_to_data_dir=raw_data_dir,
                     classes=PLASTICC_TARGET_TYPES.keys(),
                     field=field,
                     meta_data_file_name= 'plasticc_' + sample + '_metadata.csv.gz')

# Extract features for 10 days between 300 and 310
time_window = [300, 310]

# Fit first 3 available snid light curves
snids = feature_class.metadata['object_id'].values[:3]

feature_class.fit_all_snids_lc(
           raw_data_dir=raw_data_dir, snids=snids,
           output_dir=output_dir,
           vol=vol, queryable_criteria=queryable_criteria,
           get_cost=get_cost,
           tel_sizes=tel_sizes,
           tel_names=tel_names,
           spec_SNR=spec_SNR,
           time_window=time_window, sample=sample,
           number_of_processors=number_of_processors)
```


