### PR TITLE
Remove requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,12 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 
 RUN pip install --upgrade pip
 
-COPY requirements.txt .
-RUN pip install \
-	--no-cache \
-	--disable-pip-version-check \
-	--requirement requirements.txt && \
-    rm -rf /.cache/pip
+COPY pyproject.toml ./pyproject.toml
+RUN pip install dephell[full] && \
+    dephell deps convert --from=pyproject.toml --to=requirements.txt && \
+    pip install -r requirements.txt && \
+    pip uninstall -y dephell && \
+    rm -rf /root/.cache/pip
 
 
 EXPOSE 8081


### PR DESCRIPTION
This PR does two things: removes `requirements.txt` in favor of `pyproject.toml`, and modifies `Dockerfile` with a hack to use it. Probably the better way doing it would be introducing of `poetry` or some other tool to vendor pinned dependencies.

It depends on #124 (`pyproject.toml`) and should not be merged before it.